### PR TITLE
Support for V4.1

### DIFF
--- a/src/Dto/ArchiveReader.cs
+++ b/src/Dto/ArchiveReader.cs
@@ -27,7 +27,7 @@ namespace Mews.Fiscalization.SignatureChecker.Dto
             return GetOptionalEntry(files, namePrefix).ToTry(_ => $"No unique file found {namePrefix}*.".ToEnumerable());
         }
 
-        private static IOption<File> GetOptionalEntry(IReadOnlyList<File> files, string namePrefix, bool isOptional = false)
+        private static IOption<File> GetOptionalEntry(IReadOnlyList<File> files, string namePrefix)
         {
             return files.SingleOption(e => e.Name.StartsWith(namePrefix));
         }

--- a/src/Model/ArchiveVersion.cs
+++ b/src/Model/ArchiveVersion.cs
@@ -3,6 +3,7 @@ namespace Mews.Fiscalization.SignatureChecker.Model
     internal enum ArchiveVersion
     {
         v100,
-        v400
+        v400,
+        v410
     }
 }

--- a/src/Model/ReportedValue.cs
+++ b/src/Model/ReportedValue.cs
@@ -17,7 +17,8 @@ namespace Mews.Fiscalization.SignatureChecker.Model
         {
             var reportedValue = version.Match(
                 ArchiveVersion.v100, _ => GetReportedValueV1(archive),
-                ArchiveVersion.v400, _ => GetReportedValueV4(archive)
+                ArchiveVersion.v400, _ => GetReportedValueV4(archive),
+                ArchiveVersion.v410, _ => GetReportedValueV4(archive)
             );
 
             return reportedValue.Map(value => new ReportedValue(value));

--- a/src/Model/TaxSummary.cs
+++ b/src/Model/TaxSummary.cs
@@ -18,7 +18,8 @@ namespace Mews.Fiscalization.SignatureChecker.Model
         {
             return version.Match(
                 ArchiveVersion.v100, _ => GetV1TaxSummary(archive),
-                ArchiveVersion.v400, _ => GetV4TaxSummary(archive)
+                ArchiveVersion.v400, _ => GetV4TaxSummary(archive),
+                ArchiveVersion.v410, _ => GetV4TaxSummary(archive)
             );
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -48,7 +48,8 @@ namespace Mews.Fiscalization.SignatureChecker
             var computedSignature = ComputeSignature(archive);
             var hashAlgorithmName = archive.Metadata.Version.Match(
                 ArchiveVersion.v100, _ => HashAlgorithmName.SHA1,
-                ArchiveVersion.v400, _ => HashAlgorithmName.SHA256
+                ArchiveVersion.v400, _ => HashAlgorithmName.SHA256,
+                ArchiveVersion.v410, _ => HashAlgorithmName.SHA256
             );
             return cryptoServiceProvider.VerifyData(computedSignature, archive.Signature.Value, hashAlgorithmName, RSASignaturePadding.Pkcs1);
         }


### PR DESCRIPTION
Archive specification has been updated. It didn't affect any of the current signature properties, but version needs to be bumped to match the specification. It will also help us in case of future verification improvements.