### PR TITLE
Updated the signature checker to check the full archive content hash

### DIFF
--- a/src/Model/ArchiveMetadata.cs
+++ b/src/Model/ArchiveMetadata.cs
@@ -35,12 +35,14 @@ namespace Mews.Fiscalization.SignatureChecker.Model
                     "1.0", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v100),
                     "4.0", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v400),
                     "4.1", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v410),
+                    "4.2", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v420),
                     _ => Try.Error<ArchiveVersion, IEnumerable<string>>("Archive version is not supported.".ToEnumerable())
                 );
                 var archiveType = version.FlatMap(v => v.Match(
                     ArchiveVersion.v100, u => Try.Success<ArchiveType, IEnumerable<string>>(ArchiveType.Archiving),
                     ArchiveVersion.v400, u => ParseVersion4ArchiveType(metadata),
-                    ArchiveVersion.v410, u => ParseVersion4ArchiveType(metadata)
+                    ArchiveVersion.v410, u => ParseVersion4ArchiveType(metadata),
+                    ArchiveVersion.v420, u => ParseVersion4ArchiveType(metadata)
                 ));
                 var previousRecordSignature = metadata.PreviousRecordSignature.ToOption().Match(
                     s => Signature.Create(s),

--- a/src/Model/ArchiveMetadata.cs
+++ b/src/Model/ArchiveMetadata.cs
@@ -35,14 +35,14 @@ namespace Mews.Fiscalization.SignatureChecker.Model
                     "1.0", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v100),
                     "4.0", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v400),
                     "4.1", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v410),
-                    "4.2", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v420),
+                    "4.1.1", _ => Try.Success<ArchiveVersion, IEnumerable<string>>(ArchiveVersion.v411),
                     _ => Try.Error<ArchiveVersion, IEnumerable<string>>("Archive version is not supported.".ToEnumerable())
                 );
                 var archiveType = version.FlatMap(v => v.Match(
                     ArchiveVersion.v100, u => Try.Success<ArchiveType, IEnumerable<string>>(ArchiveType.Archiving),
                     ArchiveVersion.v400, u => ParseVersion4ArchiveType(metadata),
                     ArchiveVersion.v410, u => ParseVersion4ArchiveType(metadata),
-                    ArchiveVersion.v420, u => ParseVersion4ArchiveType(metadata)
+                    ArchiveVersion.v411, u => ParseVersion4ArchiveType(metadata)
                 ));
                 var previousRecordSignature = metadata.PreviousRecordSignature.ToOption().Match(
                     s => Signature.Create(s),

--- a/src/Model/ArchiveVersion.cs
+++ b/src/Model/ArchiveVersion.cs
@@ -5,6 +5,6 @@ namespace Mews.Fiscalization.SignatureChecker.Model
         v100,
         v400,
         v410,
-        v420
+        v411
     }
 }

--- a/src/Model/ArchiveVersion.cs
+++ b/src/Model/ArchiveVersion.cs
@@ -4,6 +4,7 @@ namespace Mews.Fiscalization.SignatureChecker.Model
     {
         v100,
         v400,
-        v410
+        v410,
+        v420
     }
 }

--- a/src/Model/ReportedValue.cs
+++ b/src/Model/ReportedValue.cs
@@ -19,7 +19,7 @@ namespace Mews.Fiscalization.SignatureChecker.Model
                 ArchiveVersion.v100, _ => GetReportedValueV1(archive),
                 ArchiveVersion.v400, _ => GetReportedValueV4(archive),
                 ArchiveVersion.v410, _ => GetReportedValueV4(archive),
-                ArchiveVersion.v420, _ => GetReportedValueV4(archive)
+                ArchiveVersion.v411, _ => GetReportedValueV4(archive)
             );
 
             return reportedValue.Map(value => new ReportedValue(value));

--- a/src/Model/ReportedValue.cs
+++ b/src/Model/ReportedValue.cs
@@ -18,7 +18,8 @@ namespace Mews.Fiscalization.SignatureChecker.Model
             var reportedValue = version.Match(
                 ArchiveVersion.v100, _ => GetReportedValueV1(archive),
                 ArchiveVersion.v400, _ => GetReportedValueV4(archive),
-                ArchiveVersion.v410, _ => GetReportedValueV4(archive)
+                ArchiveVersion.v410, _ => GetReportedValueV4(archive),
+                ArchiveVersion.v420, _ => GetReportedValueV4(archive)
             );
 
             return reportedValue.Map(value => new ReportedValue(value));

--- a/src/Model/TaxSummary.cs
+++ b/src/Model/TaxSummary.cs
@@ -20,7 +20,7 @@ namespace Mews.Fiscalization.SignatureChecker.Model
                 ArchiveVersion.v100, _ => GetV1TaxSummary(archive),
                 ArchiveVersion.v400, _ => GetV4TaxSummary(archive),
                 ArchiveVersion.v410, _ => GetV4TaxSummary(archive),
-                ArchiveVersion.v420, _ => GetV4TaxSummary(archive)
+                ArchiveVersion.v411, _ => GetV4TaxSummary(archive)
             );
         }
 

--- a/src/Model/TaxSummary.cs
+++ b/src/Model/TaxSummary.cs
@@ -19,7 +19,8 @@ namespace Mews.Fiscalization.SignatureChecker.Model
             return version.Match(
                 ArchiveVersion.v100, _ => GetV1TaxSummary(archive),
                 ArchiveVersion.v400, _ => GetV4TaxSummary(archive),
-                ArchiveVersion.v410, _ => GetV4TaxSummary(archive)
+                ArchiveVersion.v410, _ => GetV4TaxSummary(archive),
+                ArchiveVersion.v420, _ => GetV4TaxSummary(archive)
             );
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -60,7 +60,7 @@ namespace Mews.Fiscalization.SignatureChecker
 
         private static byte[] ComputeSignature(Archive archive, IEnumerable<Dto.File> files)
         {
-            var hash = archive.Metadata.Version.Match(
+            var archiveFilesContentHash = archive.Metadata.Version.Match(
                 ArchiveVersion.v420, _ =>
                 {
                     var applicableFiles = files.Where(f => f.Name.Contains(".csv") || f.Name.Contains(".html"));
@@ -83,7 +83,7 @@ namespace Mews.Fiscalization.SignatureChecker
                 archive.Metadata.Created.ToSignatureString(),
                 archive.Metadata.TerminalIdentification,
                 archive.Metadata.ArchiveType.ToString().ToUpperInvariant(),
-                hash.Map(h => Convert.ToBase64String(h)).GetOrElse(""),
+                archiveFilesContentHash.Map(h => Convert.ToBase64String(h)).GetOrElse(""),
                 previousSignatureFlag,
                 archive.Metadata.PreviousRecordSignature.Map(s => s.Base64UrlString).GetOrElse("")
             };

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -53,7 +52,8 @@ namespace Mews.Fiscalization.SignatureChecker
             var hashAlgorithmName = archive.Metadata.Version.Match(
                 ArchiveVersion.v100, _ => HashAlgorithmName.SHA1,
                 ArchiveVersion.v400, _ => HashAlgorithmName.SHA256,
-                ArchiveVersion.v410, _ => HashAlgorithmName.SHA256
+                ArchiveVersion.v410, _ => HashAlgorithmName.SHA256,
+                ArchiveVersion.v420, _ => HashAlgorithmName.SHA256
             );
             return cryptoServiceProvider.VerifyData(computedSignature, archive.Signature.Value, hashAlgorithmName, RSASignaturePadding.Pkcs1);
         }
@@ -63,7 +63,7 @@ namespace Mews.Fiscalization.SignatureChecker
             var hash = archive.Metadata.Version.Match(
                 ArchiveVersion.v420, _ =>
                 {
-                    var applicableFiles = files.Where(f => f.Name.Contains("csv") || f.Name.Contains("html"));
+                    var applicableFiles = files.Where(f => f.Name.Contains(".csv") || f.Name.Contains(".html"));
                     var allFilesBytes = applicableFiles.SelectMany(f => Encoding.UTF8.GetBytes(f.Content));
                     return SHA256.Create().ComputeHash(allFilesBytes.ToArray()).ToOption();
                 },

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -53,7 +53,7 @@ namespace Mews.Fiscalization.SignatureChecker
                 ArchiveVersion.v100, _ => HashAlgorithmName.SHA1,
                 ArchiveVersion.v400, _ => HashAlgorithmName.SHA256,
                 ArchiveVersion.v410, _ => HashAlgorithmName.SHA256,
-                ArchiveVersion.v420, _ => HashAlgorithmName.SHA256
+                ArchiveVersion.v411, _ => HashAlgorithmName.SHA256
             );
             return cryptoServiceProvider.VerifyData(computedSignature, archive.Signature.Value, hashAlgorithmName, RSASignaturePadding.Pkcs1);
         }
@@ -61,7 +61,7 @@ namespace Mews.Fiscalization.SignatureChecker
         private static byte[] ComputeSignature(Archive archive, IEnumerable<Dto.File> files)
         {
             var archiveFilesContentHash = archive.Metadata.Version.Match(
-                ArchiveVersion.v420, _ =>
+                ArchiveVersion.v411, _ =>
                 {
                     var applicableFiles = files.Where(f => f.Name.Contains(".csv") || f.Name.Contains(".html"));
                     var allFilesBytes = applicableFiles.SelectMany(f => Encoding.UTF8.GetBytes(f.Content));

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -17,21 +17,25 @@ namespace Mews.Fiscalization.SignatureChecker
 
             var archivePath = pathArguments.SingleOption().ToTry(_ => "Invalid arguments".ToEnumerable());
             var archiveFiles = archivePath.FlatMap(p => ZipFileReader.Read(p));
-            var archive = archiveFiles.FlatMap(files => Archive.Create(files));
+            var result = archiveFiles.FlatMap(files =>
+            {
+                var archive = Archive.Create(files);
+                var cryptoServiceProvider = GetCryptoServiceProvider(optionArguments);
 
-            var cryptoServiceProvider = GetCryptoServiceProvider(optionArguments);
-
-            var result = archive.Match(
-                a =>
+                return archive.Map(a =>
                 {
-                    return IsArchiveValid(a, cryptoServiceProvider).Match(
+                    var isArchiveValid = IsArchiveValid(a, cryptoServiceProvider, files);
+                    return isArchiveValid.Match(
                         t => "Archive signature IS valid.",
                         f => "Archive signature IS NOT valid."
                     );
-                },
-                e => e.MkLines()
+                });
+            });
+
+            result.Match(
+                r => Console.WriteLine(r),
+                errors =>  Console.WriteLine(errors.MkLines())
             );
-            Console.WriteLine(result);
         }
 
         private static RSACryptoServiceProvider GetCryptoServiceProvider(IEnumerable<string> optionArguments)
@@ -43,9 +47,9 @@ namespace Mews.Fiscalization.SignatureChecker
             );
         }
 
-        private static bool IsArchiveValid(Archive archive, RSACryptoServiceProvider cryptoServiceProvider)
+        private static bool IsArchiveValid(Archive archive, RSACryptoServiceProvider cryptoServiceProvider, IEnumerable<Dto.File> files)
         {
-            var computedSignature = ComputeSignature(archive);
+            var computedSignature = ComputeSignature(archive, files);
             var hashAlgorithmName = archive.Metadata.Version.Match(
                 ArchiveVersion.v100, _ => HashAlgorithmName.SHA1,
                 ArchiveVersion.v400, _ => HashAlgorithmName.SHA256,
@@ -54,8 +58,18 @@ namespace Mews.Fiscalization.SignatureChecker
             return cryptoServiceProvider.VerifyData(computedSignature, archive.Signature.Value, hashAlgorithmName, RSASignaturePadding.Pkcs1);
         }
 
-        private static byte[] ComputeSignature(Archive archive)
+        private static byte[] ComputeSignature(Archive archive, IEnumerable<Dto.File> files)
         {
+            var hash = archive.Metadata.Version.Match(
+                ArchiveVersion.v420, _ =>
+                {
+                    var applicableFiles = files.Where(f => f.Name.Contains("csv") || f.Name.Contains("html"));
+                    var allFilesBytes = applicableFiles.SelectMany(f => Encoding.UTF8.GetBytes(f.Content));
+                    return SHA256.Create().ComputeHash(allFilesBytes.ToArray()).ToOption();
+                },
+                _ => Option.Empty<byte[]>()
+            );
+
             var taxSummary = archive.TaxSummary;
             var reportedValue = archive.ReportedValue;
             var previousSignatureFlag = archive.Metadata.PreviousRecordSignature.Match(
@@ -69,6 +83,7 @@ namespace Mews.Fiscalization.SignatureChecker
                 archive.Metadata.Created.ToSignatureString(),
                 archive.Metadata.TerminalIdentification,
                 archive.Metadata.ArchiveType.ToString().ToUpperInvariant(),
+                hash.Map(h => Convert.ToBase64String(h)).GetOrElse(""),
                 previousSignatureFlag,
                 archive.Metadata.PreviousRecordSignature.Map(s => s.Base64UrlString).GetOrElse("")
             };


### PR DESCRIPTION
The minimum archives signature is no longer accepted, so we're now including the hash of all the archives content in the signature.