### PR TITLE
Fixed signature checker for older versions

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -83,11 +83,11 @@ namespace Mews.Fiscalization.SignatureChecker
                 archive.Metadata.Created.ToSignatureString(),
                 archive.Metadata.TerminalIdentification,
                 archive.Metadata.ArchiveType.ToString().ToUpperInvariant(),
-                archiveFilesContentHash.Map(h => Convert.ToBase64String(h)).GetOrElse(""),
+                archiveFilesContentHash.Map(h => Convert.ToBase64String(h)).GetOrNull(),
                 previousSignatureFlag,
                 archive.Metadata.PreviousRecordSignature.Map(s => s.Base64UrlString).GetOrElse("")
             };
-            return Encoding.UTF8.GetBytes(String.Join(",", signatureProperties));
+            return Encoding.UTF8.GetBytes(String.Join(",", signatureProperties.Where(p => p != null)));
         }
     }
 }


### PR DESCRIPTION
When verifying archives generated using older versions, the empty string in the signature properties is calculated and that is leading to a modified signature.